### PR TITLE
feat: yaml과 shell 스크립트 수정, 연동 & 노드 반영

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "blockly": "12.2.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "reactflow": "11.11.4"
+        "reactflow": "11.11.4",
+        "yaml-ast-parser": "^0.0.43"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -4331,6 +4332,12 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "license": "Apache-2.0"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "blockly": "12.2.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "reactflow": "11.11.4"
+    "reactflow": "11.11.4",
+    "yaml-ast-parser": "^0.0.43"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,19 @@ function App() {
     }
   }, [])
 
+  const handleShellUpdate = useCallback((shellContent: string) => {
+    console.log('=== App.handleShellUpdate 호출됨 ===')
+    console.log('Shell 내용:', shellContent)
+    console.log('flowEditorRef.current:', flowEditorRef.current)
+    
+    if (flowEditorRef.current) {
+      console.log('FlowEditor의 updateGraphFromShell 함수 호출 중...')
+      flowEditorRef.current.updateGraphFromShell(shellContent)
+    } else {
+      console.error('flowEditorRef.current가 null입니다')
+    }
+  }, [])
+
   return (
     <div style={{ width: '100%', display: 'grid', gridTemplateColumns: '1fr 520px', gap: 16, height: '100vh', padding: 16, boxSizing: 'border-box' }}>
       <div style={{ height: '100%', border: '1px solid rgba(255,255,255,.15)', borderRadius: 8, overflow: 'hidden' }}>
@@ -36,7 +49,7 @@ function App() {
       <div style={{ height: '100%', border: '1px solid rgba(255,255,255,.15)', borderRadius: 8, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
         <div style={{ padding: 12, borderBottom: '1px solid rgba(255,255,255,.15)', fontWeight: 700 }}>Output</div>
         <div style={{ padding: 12, flex: 1, overflow: 'hidden' }}>
-          <OutputPanel nodes={nodes} edges={edges} onYAMLUpdate={handleYAMLUpdate} />
+                         <OutputPanel nodes={nodes} edges={edges} onYAMLUpdate={handleYAMLUpdate} onShellUpdate={handleShellUpdate} />
         </div>
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useState, useRef } from 'react'
 import './App.css'
-import FlowEditor from './flow/FlowEditor'
+import { FlowEditorWithRef, type FlowEditorRef } from './flow/FlowEditor'
 import OutputPanel from './flow/OutputPanel'
 import type { Edge, Node } from 'reactflow'
 import type { PipelineNodeData } from './flow/codegen'
@@ -8,21 +8,35 @@ import type { PipelineNodeData } from './flow/codegen'
 function App() {
   const [nodes, setNodes] = useState<Node<PipelineNodeData>[]>([])
   const [edges, setEdges] = useState<Edge[]>([])
+  const flowEditorRef = useRef<FlowEditorRef>(null)
 
   const handleGraphChange = useCallback((ns: Node<PipelineNodeData>[], es: Edge[]) => {
     setNodes(ns)
     setEdges(es)
   }, [])
 
+  const handleYAMLUpdate = useCallback((yamlContent: string) => {
+    console.log('=== App.handleYAMLUpdate 호출됨 ===')
+    console.log('YAML 내용:', yamlContent)
+    console.log('flowEditorRef.current:', flowEditorRef.current)
+    
+    if (flowEditorRef.current) {
+      console.log('FlowEditor의 updateGraphFromYAML 함수 호출 중...')
+      flowEditorRef.current.updateGraphFromYAML(yamlContent)
+    } else {
+      console.error('flowEditorRef.current가 null입니다')
+    }
+  }, [])
+
   return (
     <div style={{ width: '100%', display: 'grid', gridTemplateColumns: '1fr 520px', gap: 16, height: '100vh', padding: 16, boxSizing: 'border-box' }}>
       <div style={{ height: '100%', border: '1px solid rgba(255,255,255,.15)', borderRadius: 8, overflow: 'hidden' }}>
-        <FlowEditor onGraphChange={handleGraphChange} />
+        <FlowEditorWithRef ref={flowEditorRef} onGraphChange={handleGraphChange} />
       </div>
       <div style={{ height: '100%', border: '1px solid rgba(255,255,255,.15)', borderRadius: 8, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
         <div style={{ padding: 12, borderBottom: '1px solid rgba(255,255,255,.15)', fontWeight: 700 }}>Output</div>
         <div style={{ padding: 12, flex: 1, overflow: 'hidden' }}>
-          <OutputPanel nodes={nodes} edges={edges} />
+          <OutputPanel nodes={nodes} edges={edges} onYAMLUpdate={handleYAMLUpdate} />
         </div>
       </div>
     </div>

--- a/src/flow/OutputPanel.tsx
+++ b/src/flow/OutputPanel.tsx
@@ -1,21 +1,28 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Edge, Node } from 'reactflow'
-import { generateShell, generateYAML } from './codegen'
+import { generateYAML, generateShell, generateShellFromYAML } from './codegen'
 import type { PipelineNodeData } from './codegen'
 
 /**
  * 그래프 상태를 받아 YAML / Shell 출력을 실시간으로 보여주는 패널
  * - 탭 전환으로 두 가지 포맷을 확인
- * - 복사/다운로드 버튼을 쉽게 추가할 수 있도록 구조를 단순히 유지
+ * - 코드를 클릭하면 편집 가능한 textarea로 변경
+ * - 편집된 내용을 저장할 수 있음
  */
 
 export interface OutputPanelProps {
   nodes: Node<PipelineNodeData>[]
   edges: Edge[]
+  onYAMLUpdate?: (yamlContent: string) => void
 }
 
-export default function OutputPanel({ nodes, edges }: OutputPanelProps) {
+export default function OutputPanel({ nodes, edges, onYAMLUpdate }: OutputPanelProps) {
   const [tab, setTab] = useState<'yaml' | 'shell'>('yaml')
+  const [isEditing, setIsEditing] = useState(false)
+  const [editedContent, setEditedContent] = useState('')
+  const [editingTab, setEditingTab] = useState<'yaml' | 'shell' | null>(null)
+  const [lastSavedYAML, setLastSavedYAML] = useState('') // 마지막으로 저장된 YAML 저장
+  const [lastSavedShell, setLastSavedShell] = useState('') // 마지막으로 저장된 Shell 저장
 
   const shell = useMemo(() => generateShell(nodes, edges), [nodes, edges])
   const yaml = useMemo(() => generateYAML(nodes, edges), [nodes, edges])
@@ -24,6 +31,160 @@ export default function OutputPanel({ nodes, edges }: OutputPanelProps) {
     // no-op; place for future side effects (copy buttons etc.)
   }, [tab])
 
+  const handleCodeClick = (content: string, tabType: 'yaml' | 'shell') => {
+    setEditedContent(content)
+    setEditingTab(tabType)
+    setIsEditing(true)
+  }
+
+  const handleSave = () => {
+    // YAML 편집 시에만 onYAMLUpdate 호출
+    if (editingTab === 'yaml' && onYAMLUpdate) {
+      onYAMLUpdate(editedContent)
+      setLastSavedYAML(editedContent) // 저장된 YAML 내용을 저장
+      
+      // YAML이 변경되면 그에 맞는 Shell 코드도 자동 생성
+      try {
+        const newShell = generateShellFromYAML(editedContent)
+        setLastSavedShell(newShell)
+        console.log('YAML 변경으로 Shell 자동 생성:', newShell)
+      } catch (error) {
+        console.error('Shell 자동 생성 실패:', error)
+        setLastSavedShell('') // 실패 시 Shell 초기화
+      }
+    } else if (editingTab === 'shell') {
+      // Shell 편집 시에는 Shell만 저장
+      setLastSavedShell(editedContent)
+    }
+    
+    // 여기서 편집된 내용을 처리할 수 있습니다
+    console.log(`Saved ${editingTab} content:`, editedContent)
+    setIsEditing(false)
+    setEditingTab(null)
+    setEditedContent('')
+  }
+
+  const handleCancel = () => {
+    setIsEditing(false)
+    setEditingTab(null)
+    setEditedContent('')
+  }
+
+  const renderContent = () => {
+    if (isEditing) {
+      return (
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+          <div style={{ marginBottom: '10px', fontSize: '14px', color: '#888' }}>
+            편집 중: {editingTab?.toUpperCase()}
+          </div>
+          <textarea
+            value={editedContent}
+            onChange={(e) => setEditedContent(e.target.value)}
+            style={{
+              flex: 1,
+              fontFamily: 'monospace',
+              fontSize: '12px',
+              backgroundColor: '#1e1e1e',
+              color: '#d4d4d4',
+              border: '1px solid #444',
+              borderRadius: '4px',
+              padding: '8px',
+              resize: 'none',
+              outline: 'none'
+            }}
+            placeholder="코드를 편집하세요..."
+          />
+          <div style={{ display: 'flex', gap: '8px', marginTop: '10px' }}>
+            <button
+              onClick={handleSave}
+              style={{
+                padding: '6px 12px',
+                backgroundColor: '#4CAF50',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer'
+              }}
+            >
+              저장
+            </button>
+            <button
+              onClick={handleCancel}
+              style={{
+                padding: '6px 12px',
+                backgroundColor: '#f44336',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer'
+              }}
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      )
+    }
+
+    // 편집 모드가 아닐 때는 마지막으로 저장된 내용이나 생성된 내용을 표시
+    const displayYAML = lastSavedYAML || yaml
+    const displayShell = lastSavedShell || shell
+
+    return (
+      <div style={{ height: '100%' }}>
+        {tab === 'yaml' ? (
+          <pre 
+            style={{ 
+              whiteSpace: 'pre-wrap', 
+              cursor: 'pointer',
+              padding: '8px',
+              borderRadius: '4px',
+              backgroundColor: '#1e1e1e',
+              border: '1px solid transparent',
+              transition: 'border-color 0.2s ease'
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.borderColor = '#444'
+              e.currentTarget.style.backgroundColor = '#2a2a2a'
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.borderColor = 'transparent'
+              e.currentTarget.style.backgroundColor = '#1e1e1e'
+            }}
+            onClick={() => handleCodeClick(displayYAML, 'yaml')}
+            title="클릭하여 편집"
+          >
+            {displayYAML}
+          </pre>
+        ) : (
+          <pre 
+            style={{ 
+              whiteSpace: 'pre-wrap', 
+              cursor: 'pointer',
+              padding: '8px',
+              borderRadius: '4px',
+              backgroundColor: '#1e1e1e',
+              border: '1px solid transparent',
+              transition: 'border-color 0.2s ease'
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.borderColor = '#444'
+              e.currentTarget.style.backgroundColor = '#2a2a2a'
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.borderColor = 'transparent'
+              e.currentTarget.style.backgroundColor = '#1e1e1e'
+            }}
+            onClick={() => handleCodeClick(displayShell, 'shell')}
+            title="클릭하여 편집"
+          >
+            {displayShell}
+          </pre>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <div style={{ display: 'flex', gap: 8, borderBottom: '1px solid rgba(255,255,255,.15)', paddingBottom: 8, marginBottom: 8 }}>
@@ -31,11 +192,7 @@ export default function OutputPanel({ nodes, edges }: OutputPanelProps) {
         <button onClick={() => setTab('shell')} className={tab === 'shell' ? 'active' : ''}>Shell</button>
       </div>
       <div style={{ flex: 1, overflow: 'auto' }}>
-        {tab === 'yaml' ? (
-          <pre style={{ whiteSpace: 'pre-wrap' }}>{yaml}</pre>
-        ) : (
-          <pre style={{ whiteSpace: 'pre-wrap' }}>{shell}</pre>
-        )}
+        {renderContent()}
       </div>
     </div>
   )

--- a/src/flow/OutputPanel.tsx
+++ b/src/flow/OutputPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { Edge, Node } from 'reactflow'
-import { generateYAML, generateShell, generateShellFromYAML } from './codegen'
+import { generateYAML, generateShell, generateShellFromYAML, generateYAMLFromShell } from './codegen'
 import type { PipelineNodeData } from './codegen'
 
 /**
@@ -14,9 +14,10 @@ export interface OutputPanelProps {
   nodes: Node<PipelineNodeData>[]
   edges: Edge[]
   onYAMLUpdate?: (yamlContent: string) => void
+  onShellUpdate?: (shellContent: string) => void
 }
 
-export default function OutputPanel({ nodes, edges, onYAMLUpdate }: OutputPanelProps) {
+export default function OutputPanel({ nodes, edges, onYAMLUpdate, onShellUpdate }: OutputPanelProps) {
   const [tab, setTab] = useState<'yaml' | 'shell'>('yaml')
   const [isEditing, setIsEditing] = useState(false)
   const [editedContent, setEditedContent] = useState('')
@@ -55,6 +56,21 @@ export default function OutputPanel({ nodes, edges, onYAMLUpdate }: OutputPanelP
     } else if (editingTab === 'shell') {
       // Shell 편집 시에는 Shell만 저장
       setLastSavedShell(editedContent)
+      
+      // Shell 편집 시 onShellUpdate 호출
+      if (onShellUpdate) {
+        onShellUpdate(editedContent)
+      }
+      
+      // Shell이 변경되면 그에 맞는 YAML 코드도 자동 생성
+      try {
+        const newYAML = generateYAMLFromShell(editedContent)
+        setLastSavedYAML(newYAML)
+        console.log('Shell 변경으로 YAML 자동 생성:', newYAML)
+      } catch (error) {
+        console.error('YAML 자동 생성 실패:', error)
+        setLastSavedYAML('') // 실패 시 YAML 초기화
+      }
     }
     
     // 여기서 편집된 내용을 처리할 수 있습니다

--- a/src/flow/codegen.ts
+++ b/src/flow/codegen.ts
@@ -278,8 +278,25 @@ export function parseYAMLToGraph(yamlContent: string): { nodes: Node<PipelineNod
                   id: `edge-${index - 1}`,
                   source: nodes[index - 1].id,
                   target: node.id,
+                  type: 'smoothstep',
                   animated: true,
-                  markerEnd: { type: MarkerType.ArrowClosed }
+                  markerEnd: { 
+                    type: MarkerType.ArrowClosed,
+                    width: 20,
+                    height: 20
+                  },
+                  label: `${index}`,
+                  labelStyle: {
+                    fill: '#fff',
+                    fontWeight: 600,
+                    fontSize: '12px'
+                  },
+                  labelBgStyle: {
+                    fill: '#1a192b',
+                    fillOpacity: 0.8
+                  },
+                  labelBgPadding: [4, 4],
+                  labelBgBorderRadius: 4
                 }
                 edges.push(edge)
               }
@@ -669,11 +686,24 @@ export function parseShellToGraph(shellContent: string): { nodes: Node<PipelineN
             source: `shell-step-${nodeIndex - 1}`,
             target: `shell-step-${nodeIndex}`,
             type: 'smoothstep',
+            animated: true,
             markerEnd: {
               type: MarkerType.ArrowClosed,
               width: 20,
               height: 20
-            }
+            },
+            label: `${nodeIndex}`,
+            labelStyle: {
+              fill: '#fff',
+              fontWeight: 600,
+              fontSize: '12px'
+            },
+            labelBgStyle: {
+              fill: '#1a192b',
+              fillOpacity: 0.8
+            },
+            labelBgPadding: [4, 4],
+            labelBgBorderRadius: 4
           }
           edges.push(edge)
         }


### PR DESCRIPTION
현재까지의 수정 사항:
1. yaml 과 shell 스크립트를 수정할 수 있고, 서로 연동된다
2. yaml과 shell 스크립트의 수정사항이 노드로 반영된다

수정해야 할 사항: 
1. 자동 노드 생성 이후에 드래그 & 드랍 으로 새로 연결 시, 간선 숫자가 하나 더 높게 나온다
4. shell, yaml 스크립트 색깔 변경 (잘 보이지 않음) 
5. shell, yaml코드 수정시 서로의 탭으로 넘어가지 않게 해야 한다 
